### PR TITLE
change username input selector

### DIFF
--- a/packages/rocketchat-ui-login/username/username.coffee
+++ b/packages/rocketchat-ui-login/username/username.coffee
@@ -33,7 +33,7 @@ Template.username.events
 		button = $(event.target).find('button.login')
 		RocketChat.Button.loading(button)
 
-		value = $("input").val().trim()
+		value = $("#username").val().trim()
 		if value is ''
 			username.empty = true
 			instance.username.set(username)


### PR DESCRIPTION
@RocketChat/core 

The jQuery selector used to get the username input is not specific. This can lead to some unexpected behavior (e.g when adding babrahams:constellation, which include other inputs)

